### PR TITLE
Make this check an error as it breaks puppet 4 run

### DIFF
--- a/lib/puppet-lint/plugins/check_unquoted_string_in_case.rb
+++ b/lib/puppet-lint/plugins/check_unquoted_string_in_case.rb
@@ -30,7 +30,7 @@ def notify_tokens(type, sep_type, message)
         s = r.prev_token
         while s.type != :NEWLINE and s.type != :LBRACE
           if s.type == :NAME || s.type == :CLASSREF
-            notify :warning, {
+            notify :error, {
               :message => message,
               :line    => s.line,
               :column  => s.column,


### PR DESCRIPTION
This should be an ERROR as Puppet4 catalog doesn't compile anymore without quotes.

Regards

Olivier
